### PR TITLE
Update flutter_apns_only.dart

### DIFF
--- a/flutter_apns_only/lib/flutter_apns_only.dart
+++ b/flutter_apns_only/lib/flutter_apns_only.dart
@@ -25,9 +25,10 @@ class ApnsPushConnectorOnly {
   ApnsMessageHandler? _onLaunch;
   ApnsMessageHandler? _onResume;
 
-  void requestNotificationPermissions(
-      [IosNotificationSettings iosSettings = const IosNotificationSettings()]) {
-    _channel.invokeMethod(
+  Future<void> requestNotificationPermissions(
+      [IosNotificationSettings iosSettings =
+          const IosNotificationSettings()]) async {
+    await _channel.invokeMethod(
         'requestNotificationPermissions', iosSettings.toMap());
   }
 


### PR DESCRIPTION
fix: 알림권한설정 비동기처리